### PR TITLE
Fix link path in Milestone 1 documentation

### DIFF
--- a/instruction/tweeter/milestone-1/milestone-1.md
+++ b/instruction/tweeter/milestone-1/milestone-1.md
@@ -2,6 +2,6 @@
 
 ## Pre-class Preparation
 
-Read the [Course Project](../../tweeter/project-overview/tweeter.md) specification.
+Read the [Course Project](../../../tweeter/project-overview/tweeter.md) specification.
 
 Read the [Milestone 1: Tweeter Web UI Cleanup](../../../tweeter/milestone-1/milestone-1.md) specification.


### PR DESCRIPTION
<img width="1678" height="378" alt="Screenshot 2025-09-10 144828" src="https://github.com/user-attachments/assets/a1b2afa2-7a62-4adc-ac85-b898f6a48a22" />
