### PR TITLE
Update standalone-typescript-project-setup-instructions.md

### DIFF
--- a/instruction/typescript-fundamentals-1/standalone-typescript-project-setup-instructions.md
+++ b/instruction/typescript-fundamentals-1/standalone-typescript-project-setup-instructions.md
@@ -17,7 +17,7 @@ npm is already installed on your computer.
 1. Create an src directory
 1. Create a typescript file in your src directory and write your typescript code
 
-## Optional Steps
+## Optional Steps (Only if you don't run your typescript code with npx)
 
 1. Run `npx tsc --init`
 1. Edit compilerOptions in tsconfig.json to contain the following settings:
@@ -32,6 +32,9 @@ npm is already installed on your computer.
 **Note:** If you do not include these steps, ts-node will use reasonable defaults when running your code.
 
 ## Running Your Typescript Code
+
+> [!NOTE]
+> If you want to run the following command to run your code, the optional step is not optional. You can run your code in another way if you would would like instead
 
 `npx ts-node src/<Your Typescript File.ts>`
 

--- a/instruction/typescript-fundamentals-1/standalone-typescript-project-setup-instructions.md
+++ b/instruction/typescript-fundamentals-1/standalone-typescript-project-setup-instructions.md
@@ -16,9 +16,6 @@ npm is already installed on your computer.
 1. Run `npm install ts-node --save-dev`
 1. Create an src directory
 1. Create a typescript file in your src directory and write your typescript code
-
-## Optional Steps (Only if you don't run your typescript code with npx)
-
 1. Run `npx tsc --init`
 1. Edit compilerOptions in tsconfig.json to contain the following settings:
     ```
@@ -32,9 +29,6 @@ npm is already installed on your computer.
 **Note:** If you do not include these steps, ts-node will use reasonable defaults when running your code.
 
 ## Running Your Typescript Code
-
-> [!NOTE]
-> If you want to run the following command to run your code, the optional step is not optional. You can run your code in another way if you would would like instead
 
 `npx ts-node src/<Your Typescript File.ts>`
 


### PR DESCRIPTION
A lot of students try to create a typescript project and run into a problem because they haven't downloaded npx to have a tsconfig file. We need to tell students this isn't optional.