### PR TITLE
Milestone 1 faq

### DIFF
--- a/tweeter/milestone-1/milestone-1-faq.md
+++ b/tweeter/milestone-1/milestone-1-faq.md
@@ -9,3 +9,7 @@ Short explanation: React doesn't see a difference between our Scroller component
 - [CS 340 M1 Part 2 Demo](https://www.youtube.com/watch?v=MeXHcXQpUCY&t=1068s)
 
 - [CS 340 M2B Component Refactoring Overview](https://youtu.be/kEsC0rbVpPY?si=bDHWPdo6n-s_PdJe&t=392)
+
+## Clicking on a user should navigate to that user's page
+
+Clicking on a user should preserve the current feature URL. This feature URL would be `/feed`, `/story`, `/followers`, or `/followees`. If you click on a user and go to a different feature URL, then you likely have it hardcoded in your StatusItem or UserItem

--- a/tweeter/milestone-1/milestone-1-faq.md
+++ b/tweeter/milestone-1/milestone-1-faq.md
@@ -2,4 +2,10 @@
 
 ## Scroll Data Persists Between Story/Feed and Followers/Following
 
-This is solved later in Milestone 2B, but if you'd like to understand and fix this now, you can look at the M2B View layer video (starts at 6:40): [Video](https://youtu.be/kEsC0rbVpPY?si=bDHWPdo6n-s_PdJe&t=400)
+This isn't a super big issue right now, but it will be for future phases when we add actual data.
+
+Short explanation: React doesn't see a difference between our Scroller components that remove duplicate code. We need to use a key to tell React that they are different to force React to rerender these components. These videos further explain this.
+
+- [CS 340 M1 Part 2 Demo](https://www.youtube.com/watch?v=MeXHcXQpUCY&t=1068s)
+
+- [CS 340 M2B Component Refactoring Overview](https://youtu.be/kEsC0rbVpPY?si=bDHWPdo6n-s_PdJe&t=392)


### PR DESCRIPTION
Update to the Milestone 1 FAQ

## Scroll Data Persists

I noticed that this FAQ states that it was explained in Milestone 2, which is true, but in M1 Demo Part 2 it is also discussed, so I wanted to include the video link and give a small description in case people want the short version. 

## New FAQ

While recoding the Tweeter project myself, I encountered this issue where my StatusItem was hardcoded to go to `/story` instead of using the prop's featureURL. This seemed like it could be a frequently encountered problem (I'm assuming since I haven't been a TA for Milestone 1 yet), so I thought I would add it in here just in case.