### PR TITLE
Fix Slack invitation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The content for this course can be accessed using the following links:
 - [Image Editor](image-editor/image-editor.md) - Image Editor assignment specification
 - [Tweeter](tweeter/project-overview/tweeter.md) - Tweeter project overview and specifications
     - [M1](tweeter/milestone-1/milestone-1.md) - [M2A](tweeter/milestone-2a/milestone-2a.md) - [M2B](tweeter/milestone-2b/milestone-2b.md) - [M2C](tweeter/milestone-2c/milestone-2c.md) - [M2C Docs](tweeter/milestone-2c/milestone-2c-docs.md) - [M3](tweeter/milestone-3/milestone-3.md) - [M3 Docs](tweeter/milestone-3/milestone-3-docs.md) - [M4A](tweeter/milestone-4a/milestone-4a.md) - [M4B](tweeter/milestone-4b/milestone-4b.md)
-- [Slack](https://join.slack.com/t/byu-cs-340/shared_invite/zt-3paze3sk7-Wf6M7FkJXlIuWE2KoalifQ) - Invitation to course Slack
+- [Slack](https://join.slack.com/t/byu-cs-340/shared_invite/zt-48u52c41s-6CjZZJDi20rVBaIcsNod0g) - Invitation to course Slack
     - If you've taken this course in a previous semester, the Slack link may not work. Let us know at cs340ta.byu@gmail.com and we can fix it for you.
 - [AWS Account Info](./tweeter/project-overview/aws-account.md)
 - [Canvas](https://byu.instructure.com/) - Take quizzes and view grades


### PR DESCRIPTION
A Student found out that the slack link isn't working anymore (The link is no longer active), so I created a new invitation link with no expiration date. So updated the slack link on README.md